### PR TITLE
fixes faulty redirect from new thread

### DIFF
--- a/web.go
+++ b/web.go
@@ -360,7 +360,7 @@ func createNewThread(w http.ResponseWriter, r *http.Request) {
 		serverError(w, r, err)
 		// handle
 	}
-	http.Redirect(w, r, fmt.Sprintf("/%s/%d", f.Slug, tid), http.StatusSeeOther)
+	http.Redirect(w, r, fmt.Sprintf("%s/%d", f.Slug, tid), http.StatusSeeOther)
 }
 
 // hashes string and builds png avatar


### PR DESCRIPTION
originally createNewThread would redirect to paths starting with //. this commit removes that extra / to correctly open the new thread